### PR TITLE
Rr/form codeyacs

### DIFF
--- a/shared/codes.php
+++ b/shared/codes.php
@@ -2928,6 +2928,8 @@ Class Codes {
 		// link to a form
 		case 'form':
 
+         include_once $context['path_to_root'].'forms/forms.php';
+         
 			// maybe an alternate title has been provided
 			$attributes = preg_split("/\s*,\s*/", $id, 2);
 			$id = $attributes[0];
@@ -2946,7 +2948,7 @@ Class Codes {
 					$text = Skin::strip($item['title']);
 
 				// make a link to the target page
-				$url =& Forms::get_url($item['']);
+				$url =& Forms::get_url($item['id']);
 
 				// return a complete anchor
 				$output =& Skin::build_link($url, $text, $type);


### PR DESCRIPTION
correction du code yacs [form=id] qui déclenchait une erreur PHP
http://www.yacs.fr/article-7318-appel-d-un-formulaire-dans-une-section
- ajout d'un include_once
- ajout d'une clé 'id' en argument de tableau
