### PR TITLE
Rr/images direct edit

### DIFF
--- a/shared/codes.php
+++ b/shared/codes.php
@@ -3050,7 +3050,11 @@ Class Codes {
 			}
 
 			// use the skin
-			$output =& Skin::build_image($variant, $href, $title, $link);
+			if (surfer::is_empowered())
+			   //build editable image
+			   $output =& Skin::build_image($variant, $href, $title, $link, $id);
+			else 
+			   $output =& Skin::build_image($variant, $href, $title, $link);
 			return $output;
 
 		// embed a stack of images

--- a/skins/_reference/yacs.css
+++ b/skins/_reference/yacs.css
@@ -2557,6 +2557,31 @@ div.external_image { /* display an image hosted elsewhere -- [img]url[/img] */
 	margin-top: 0;
 }
 
+/* direct edition link */
+.thumbnail_image, 
+.left_image,
+.right_image,
+.center_image,
+.inline_image
+{position:relative;}
+
+.image_edit {
+	display:none;
+	position:absolute;
+	top:0;left:0;
+}
+
+.center_image .image_edit {
+	left : 45%;
+}  
+
+.thumbnail_image:hover .image_edit,
+.left_image:hover .image_edit,
+.right_image:hover .image_edit,
+.center_image:hover .image_edit,
+.inline_image:hover .image_edit
+{display:block;}
+
 /* Skin::build_list() */
 
 dl.column { /* one single column */

--- a/skins/skin_skeleton.php
+++ b/skins/skin_skeleton.php
@@ -1169,10 +1169,11 @@ Class Skin_Skeleton {
 	 * @param string the image href
 	 * @param string the image title
 	 * @param string a link to make a clickable image, if any
+	 * @param string id of image, to display edition direct link, if desired
 	 * @return the HTML to display
 	 *
 	 */
-	function &build_image($variant, $href, $title, $link='') {
+	function &build_image($variant, $href, $title, $link='',$id='') {
 		global $context;
 
 		// sanity check
@@ -1253,6 +1254,8 @@ Class Skin_Skeleton {
 
 		} else
 			$text .= $image;
+			
+			
 
 		// make the title visible as a caption
 		if($title && $with_caption)
@@ -1261,6 +1264,15 @@ Class Skin_Skeleton {
 		// end of freedom
 		if($complement)
 			$text .= '</span>';
+			
+		//edit image direct access
+      $edit = '';
+      if((($variant=='center')||($variant=='right')||($variant=='left')||($variant=='thumbnail')||($complement=='large')) && $id) {
+         Skin::define_img('IMAGES_EDIT_IMG', 'images/edit.gif');
+         $edit_title = i18n::s('Update this image').' ['.$id.']';
+         $edit = '<span class="image_edit">'.Skin::build_link(Images::get_url($id,'edit'),IMAGES_EDIT_IMG,NULL,$edit_title).'</span>';
+         }
+      $text .= $edit;   	
 
 		// end of wrapper
 		$text .= '</span>';


### PR DESCRIPTION
Editing a image form a page is a long way :
- edit the page
- chose media tabs
- open image list
- chose (tiny link) "update this image"

this update brings a icon link that is displayed on top of images, while hovering them with mouse, witch is a direct link to image's edition page.

see http://www.yacs.fr/a~2xl
