### PR TITLE
added backticks around the reserved word rank and corrected warning o…

### DIFF
--- a/articles/articles.php
+++ b/articles/articles.php
@@ -3584,7 +3584,7 @@ Class Articles {
 		$indexes['INDEX overlay_id']	= "(overlay_id)";
 		$indexes['INDEX publish_date']	= "(publish_date)";
 		$indexes['INDEX publish_id']	= "(publish_id)";
-		$indexes['INDEX `rank`']			= "(rank)";
+		$indexes['INDEX `rank`'] 	    = "(`rank`)";
 		$indexes['INDEX review_date']	= "(review_date)";
 		$indexes['INDEX title'] 		= "(title(255))";
 		$indexes['FULLTEXT INDEX']		= "full_text(title, source, introduction, description)";

--- a/categories/categories.php
+++ b/categories/categories.php
@@ -2141,7 +2141,7 @@ Class Categories {
 		$indexes['INDEX keywords']		= "(keywords(255))";
 		$indexes['INDEX nick_name']             = "(nick_name)";
 		$indexes['INDEX path']			= "(path(255))";
-		$indexes['INDEX `rank`']			= "(rank)";
+		$indexes['INDEX `rank`']			= "(`rank`)";
 		$indexes['INDEX title'] 		= "(title(255))";
 		$indexes['FULLTEXT INDEX']              = "full_text(title, introduction, description, keywords)";
 

--- a/files/files.php
+++ b/files/files.php
@@ -2989,8 +2989,8 @@ Class Files {
 		$indexes['PRIMARY KEY'] 		= "(id)";
 		$indexes['INDEX active']		= "(active)";
 		$indexes['INDEX anchor']		= "(anchor)";
-                $indexes['INDEX overlay_id']    = "(overlay_id)";
-		$indexes['INDEX `rank`']			= "(rank)";
+        $indexes['INDEX overlay_id']    = "(overlay_id)";
+		$indexes['INDEX `rank`']		= "(`rank`)";
 		$indexes['INDEX title'] 		= "(title(25))";
 		$indexes['FULLTEXT INDEX']		= "full_text(title, source, keywords)";
 

--- a/sections/sections.php
+++ b/sections/sections.php
@@ -3483,7 +3483,7 @@ Class Sections {
 		$indexes['INDEX language']          = "(language)";
 		$indexes['INDEX nick_name']         = "(nick_name)";
 		$indexes['INDEX overlay_id']        = "(overlay_id)";
-		$indexes['INDEX `rank`']              = "(rank)";
+		$indexes['INDEX `rank`']            = "(`rank`)";
 		$indexes['INDEX title']             = "(title(12))";
 		$indexes['FULLTEXT INDEX']          = "full_text(title, introduction, description)";
 

--- a/users/users.php
+++ b/users/users.php
@@ -579,7 +579,7 @@ Class Users {
             
             $cols = array();
             while($col = SQL::fetch($result)) {
-                $cols[] = $col['column_name'];
+                $cols[] = $col['COLUMN_NAME'];
             }
             
             SQL::free($result);


### PR DESCRIPTION
…n populate.php: it returns the columns under the name COLUMN_NAME (in uppercase), not column_name (in lowercase).