### PR TITLE
fix: PHP 8.x compatibility and various bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,14 @@ temporary/
 scripts/run_once/*.done
 scripts/staging/
 
+.DS_Store
+temporary/
+
+# ignore Claude Code files
+.claude/
+CLAUDE.md
+CLAUDE-*.md
+
 # ignore backup files
 *.bak
 

--- a/articles/move.php
+++ b/articles/move.php
@@ -58,14 +58,17 @@ elseif(isset($context['arguments'][1]))
 // ensure that the target section is defined in behaviors of the source section
 if($destination && is_object($anchor)) {
 	$behaviors = $anchor->get_behaviors();
-	if(!preg_match('/move_on_article_access\s+'.preg_quote($destination, '/').'/i', $behaviors)) {
+	if(!preg_match('/^move_\w+\s+'.preg_quote($destination, '/').'/im', $behaviors)) {
 		Safe::header('Status: 400 Bad Request', TRUE, 400);
 		Logger::error(i18n::s('Request is invalid.'));
 		$destination = NULL;
 	}
 }
 
-// load the target section, by id , or with a full reference
+// load the target section, by id, or with a full reference
+// normalize bare nick (e.g. 'my-section') to 'section:my-section' — Anchors::get() requires a type prefix
+if($destination && !is_numeric($destination) && strpos($destination, ':') === false)
+	$destination = 'section:'.$destination;
 $destination = Anchors::get($destination);
 
 // clear the tab we are in, if any

--- a/behaviors/move_on_article_access.php
+++ b/behaviors/move_on_article_access.php
@@ -63,7 +63,7 @@ class Move_on_article_access extends Behavior {
 						$tokens[1] = sprintf(i18n::s('Move to %s'), $section->get_title());
 
 					// the target link to move the page
-					$link = Articles::get_url(str_replace('article:', '', $anchor), 'move', str_replace('section:', '', $section->get_reference()));
+					$link = Articles::get_url(str_replace('article:', '', $anchor), 'move', $tokens[0]);
 
 					// make a sub-menu
 					$menu = array_merge(array($link => array('', $tokens[1], '', 'button')), $menu);

--- a/files/files.php
+++ b/files/files.php
@@ -1464,7 +1464,7 @@ Class Files {
 	public static function get_path($reference, $space='files') {
 		global $context;
 
-		return $space.'/'.str_replace(':', '/', $reference);
+		return $space.'/'.str_replace(':', '/', $reference ?? '');
 	}
 
 	/**

--- a/images/image.php
+++ b/images/image.php
@@ -91,7 +91,12 @@ Class Image extends Anchor {
                 if(Image::use_magic()) {
                     $adjusted = $image->resizeImage($adjust_width, $adjust_height, Imagick::FILTER_POINT, 1);
                 } else {
-                    if(($image_information[2] == 2) && is_callable('ImageCreateTrueColor') && ($adjusted = ImageCreateTrueColor($adjust_width, $adjust_height))) {
+                    if(($image_information[2] == 2 || $image_information[2] == 3) && is_callable('ImageCreateTrueColor') && ($adjusted = ImageCreateTrueColor($adjust_width, $adjust_height))) {
+                            if($image_information[2] == 3) {
+                                imagealphablending($adjusted, FALSE);
+                                imagesavealpha($adjusted, TRUE);
+                                imagefill($adjusted, 0, 0, imagecolorallocatealpha($adjusted, 0, 0, 0, 127));
+                            }
                             ImageCopyResampled($adjusted, $image, 0, 0, 0, 0, $adjust_width, $adjust_height, $width, $height);
                     }
                     if((!$adjusted) && is_callable('ImageCreate') && ($adjusted = ImageCreate($adjust_width, $adjust_height))) {
@@ -364,7 +369,12 @@ Class Image extends Anchor {
                 if(Image::use_magic()) {
                     $thumbnail = $image->resizeImage($thumbnail_width, $thumbnail_height, Imagick::FILTER_POINT, 1);
                 } else {
-                    if(($image_information[2] == 2) && is_callable('ImageCreateTrueColor') && ($thumbnail = ImageCreateTrueColor($thumbnail_width, $thumbnail_height))) {
+                    if(($image_information[2] == 2 || $image_information[2] == 3) && is_callable('ImageCreateTrueColor') && ($thumbnail = ImageCreateTrueColor($thumbnail_width, $thumbnail_height))) {
+                            if($image_information[2] == 3) {
+                                imagealphablending($thumbnail, FALSE);
+                                imagesavealpha($thumbnail, TRUE);
+                                imagefill($thumbnail, 0, 0, imagecolorallocatealpha($thumbnail, 0, 0, 0, 127));
+                            }
                             ImageCopyResampled($thumbnail, $image, 0, 0, 0, 0, $thumbnail_width, $thumbnail_height, $width, $height);
                     }
                     if((!$thumbnail) && is_callable('ImageCreate') && ($thumbnail = ImageCreate($thumbnail_width, $thumbnail_height))) {

--- a/images/images.php
+++ b/images/images.php
@@ -894,7 +894,7 @@ Class Images {
                 $indice = ($i==0)?'':(string) $i;
                 
                 if($img = Files::get_uploaded('upload'.$indice)) {
-                    $as_thumb = ($indice=='')?true:false;
+                    $as_thumb = false;
                     Images::upload_to($anchor, $img, $as_thumb, $postnow);
                 }
             }

--- a/overlays/event.php
+++ b/overlays/event.php
@@ -1980,6 +1980,10 @@ class Event extends Overlay {
 		// sent notification to all enrolled persons
 		if($mail) {
 
+			// anchor must be available to send notifications
+			if(!is_callable(array($this->anchor, 'get_reference')))
+				return;
+
 			// list enrolment for this meeting
 			$query = "SELECT user_id FROM ".SQL::table_name('enrolments')." WHERE anchor LIKE '".SQL::escape($this->anchor->get_reference())."'";
 			if($result = SQL::query($query)) {

--- a/overlays/forms/fetch_as_csv.php
+++ b/overlays/forms/fetch_as_csv.php
@@ -36,7 +36,7 @@ $id = strip_tags($id);
 
 // encode ISO-8859-1 argument, if any
 if(isset($_SERVER['HTTP_ACCEPT_CHARSET']) && preg_match('/^iso-8859-1/i', $_SERVER['HTTP_ACCEPT_CHARSET']))
-	$id = utf8_encode($id);
+	$id = mb_convert_encoding($id, 'ISO-8859-1', 'UTF-8');
 
 // get the item from the database
 $item = Articles::get($id);

--- a/sections/sections.php
+++ b/sections/sections.php
@@ -1620,10 +1620,8 @@ Class Sections {
 
 				// process all matching sections
 				while($row = SQL::fetch($result)) {
-                                    
-                                        if(!isset($item['id'])) continue;
 
-					if($row['id'] == $item['id']) {
+					if(isset($item['id']) && $row['id'] == $item['id']) {
 
 						if($children)
 							$family .= '<input type="radio" name="anchor" value="section:'.$item['id'].'" checked="checked" /> '.Codes::beautify_title($item['title'])
@@ -1656,10 +1654,8 @@ Class Sections {
 
 					// process all matching sections
 					while($row = SQL::fetch($result)) {
-                                            
-                                                if(!isset($item['id'])) continue;
-                                            
-						if($row['id'] == $item['id']) {
+
+						if(isset($item['id']) && $row['id'] == $item['id']) {
 
 							if($children)
 								$family .= '<input type="radio" name="anchor" value="section:'.$item['id'].'" checked="checked" /> '.Codes::beautify_title($item['title'])

--- a/shared/global.php
+++ b/shared/global.php
@@ -124,7 +124,8 @@ $context['country_code'] = '--';
 $context['current_focus'] = array();
 
 // handle of the current page (e.g., 'article:123')
-$context['current_item'] = NULL;
+$context['current_item']   = NULL;
+$context['current_action'] = NULL;
 
 // where developers can add debugging messages --one string per row
 $context['debug'] = array();


### PR DESCRIPTION
- overlays/forms/fetch_as_csv.php: replace deprecated utf8_encode() with mb_convert_encoding()
- overlays/event.php: guard against null anchor before sending event notifications
- files/files.php: handle null reference in Files::get_path() with null coalescing operator
- shared/global.php: initialize $context['current_action'] to NULL to prevent undefined key warning
- images/image.php: extend truecolor resampling to PNG and preserve alpha transparency in adjust() and shrink()
- images/images.php: do not auto-set first uploaded image as icon
- sections/sections.php: fix section list empty on new section form (replace continue guard with isset check)
- articles/move.php: generalize move behavior regex to any move_* behavior and normalize section nick before Anchors::get()
- behaviors/move_on_article_access.php: use declared nick instead of resolved numeric ID in move URL
- .gitignore: exclude Claude Code files