### PR TITLE
fix: break anchoring cycles in get_focus() and get_path_bar()

### DIFF
--- a/categories/category.php
+++ b/categories/category.php
@@ -139,14 +139,14 @@ Class Category extends Anchor {
 	 *
 	 * @see shared/anchor.php
 	 */
-	function get_path_bar() {
-	    	   		    
+	function get_path_bar($visited = array()) {
+
 		// no item bound
 		if(!isset($this->item['id']))
 			return NULL;		
 		
-		// standard path
-		$path = Anchor::get_path_bar();
+		// standard path -- forward visited references to break anchoring cycles
+		$path = Anchor::get_path_bar($visited);
 		
 		// add categories root
 		if(!$this->item['anchor'])		

--- a/shared/anchor.php
+++ b/shared/anchor.php
@@ -468,16 +468,20 @@ abstract class Anchor {
 	 * This function lists containers of the content tree,
 	 * from top level down to this item.
 	 *
+	 * @param array references already climbed, used to break anchoring cycles
 	 * @return array of anchor references (e.g., array('section:123', 'article:456') )
 	 */
-	function get_focus() {
+	function get_focus($visited = array()) {
 		 // get the parent
 		if(!isset($this->anchor) && isset($this->item['anchor']))
 			$this->anchor = Anchors::get($this->item['anchor']);
 
-		// the parent level
-		if(is_object($this->anchor))
-			$focus = $this->anchor->get_focus();
+		// remember this level to detect anchoring cycles
+		$visited[] = $this->get_reference();
+
+		// the parent level -- unless it has already been visited (cyclic anchor)
+		if(is_object($this->anchor) && !in_array($this->anchor->get_reference(), $visited))
+			$focus = $this->anchor->get_focus($visited);
 		else
 			$focus = array();
 
@@ -731,9 +735,10 @@ abstract class Anchor {
 	 *
 	 * To be overloaded into derived class
 	 *
+	 * @param array references already climbed, used to break anchoring cycles
 	 * @return an array of $url => $label
 	 */
-	function get_path_bar() {
+	function get_path_bar($visited = array()) {
 		global $context;
 
 		// no item bound
@@ -744,10 +749,13 @@ abstract class Anchor {
 		if(!isset($this->anchor))
 			$this->anchor = Anchors::get($this->item['anchor']);
 
-		// the parent level
+		// remember this level to detect anchoring cycles
+		$visited[] = $this->get_reference();
+
+		// the parent level -- unless it has already been visited (cyclic anchor)
 		$parent = array();
-		if(is_object($this->anchor))
-			$parent = $this->anchor->get_path_bar();
+		if(is_object($this->anchor) && !in_array($this->anchor->get_reference(), $visited))
+			$parent = $this->anchor->get_path_bar($visited);
 
 		// this item
 		$url = $this->get_permalink();

--- a/users/user.php
+++ b/users/user.php
@@ -190,10 +190,11 @@ Class User extends Anchor {
 	 * This function lists containers of the content tree,
 	 * from top level down to this item.
 	 *
+	 * @param array references already climbed, used to break anchoring cycles
 	 * @return array of anchor references (e.g., array('section:123', 'article:456') )
 	 */
-	function get_focus() {
-		
+	function get_focus($visited = array()) {
+
 		$focus = array();
 
 		// append this level
@@ -211,9 +212,10 @@ Class User extends Anchor {
 	 *
 	 * @return an array of $url => $label
 	 *
+	 * @param array references already climbed, used to break anchoring cycles
 	 * @see shared/anchor.php
 	 */
-	function get_path_bar() {
+	function get_path_bar($visited = array()) {
 
 		// load localized strings
 		i18n::bind('users');


### PR DESCRIPTION
A self-referential anchor (e.g. a section whose anchor points to its own id) made get_focus()/get_path_bar() climb the parent chain for ever, until PHP ran out of memory (Allowed memory size exhausted in shared/anchors.php).

Thread the references already climbed through an optional $visited argument and stop as soon as a parent has already been seen. The guard is backward compatible (optional parameter), covers every anchor type (section, article, category) and any cycle length, and leaves normal breadcrumbs unchanged.

Because $visited is added to the Anchor base signatures, every subclass that overrides these methods is updated to keep a compatible signature: User (which overrides both get_focus() and get_path_bar()) and Category::get_path_bar(). Omitting User triggers a Fatal Error at class load time ("Declaration of User::get_focus() must be compatible with Anchor::get_focus").