### PR TITLE
fix: replace deprecated mysqli_ping() with a SELECT 1 sentinel query

### DIFF
--- a/shared/sql.php
+++ b/shared/sql.php
@@ -545,21 +545,13 @@ Class SQL {
 		if(!$connection)
 			return FALSE;
 
-		// reopen a connection if database is not reachable anymore
-		if(is_callable('mysqli_ping'))
-			$reached = mysqli_ping($connection);
-		else
-			$reached = mysql_ping($connection);
+		// check that the database is still reachable with a lightweight sentinel query
+		// (mysqli_ping() is deprecated since PHP 8.4, along with mysqli auto-reconnect)
+		$reached = (@mysqli_query($connection, 'SELECT 1') !== FALSE);
 
-		// also ping the database for users, if any
-		if(isset($context['users_connection']) && $context['users_connection'] && ($context['users_connection'] !== $connection)) {
-
-			if(is_callable('mysqli_ping'))
-				mysqli_ping($context['users_connection']);
-			else
-				mysql_ping($context['users_connection']);
-
-		}
+		// also check the database for users, if any
+		if(isset($context['users_connection']) && $context['users_connection'] && ($context['users_connection'] !== $connection))
+			@mysqli_query($context['users_connection'], 'SELECT 1');
 
 		// job done
 		return $reached;


### PR DESCRIPTION
mysqli_ping() and mysqli auto-reconnect are deprecated as of PHP 8.4. Sql::ping() now probes the connection with a lightweight SELECT 1 query, preserving the "return FALSE when the database is unreachable" semantics relied upon by query() and the maintenance scripts. Dead mysql_ping() fallbacks (removed in PHP 7) are dropped.