### PR TITLE
fix: guard null cells against preg_match() in table_row() (PHP 8.4)

### DIFF
--- a/skins/skin_skeleton.php
+++ b/skins/skin_skeleton.php
@@ -5655,6 +5655,8 @@ Class Skin_Skeleton {
 			// column headers are clickable links
 			$index = 0;
 			foreach($cells as $cell) {
+				// PHP 8.4: preg_match() no longer accepts null
+				$cell = (string)$cell;
 
 				// take care of cell alignment
 				$prefix = '';
@@ -5710,6 +5712,8 @@ Class Skin_Skeleton {
 		$text = '';
 		$count = 1;
 		foreach($cells as $cell) {
+			// PHP 8.4: preg_match() no longer accepts null
+			$cell = (string)$cell;
 			// west=...
 			if(preg_match('/^west=(.*)$/is', $cell, $matches))
 				$text .= $cell_opened.' class="west">'.$matches[1].$cell_suffix;


### PR DESCRIPTION
PHP 8.4 deprecates passing null to preg_match(). Empty cells of a [table] code come through as null in table_row(); cast each cell to string at the top of both loops.