### PR TITLE
refactor: extract [php]/[snippet] into a movable codes/code_pre.php e…

### DIFF
--- a/codes/code_pre.php
+++ b/codes/code_pre.php
@@ -17,8 +17,8 @@
  * URL or an e-mail address found inside the block). codes/codes.php loads this
  * extension at that early point and the generic code_*.php scan skips it.
  *
- * The actual rendering lives in Codes::render_pre(), a shared utility also used
- * outside the codes engine (scripts/browse.php); this class only binds the tags.
+ * Besides the codes engine, render() is also called directly by scripts/browse.php
+ * to highlight a whole script file.
  *
  * @author Bernard Paques (rendering)
  * @author Alexis Raimbault (extension mechanism)
@@ -35,12 +35,54 @@ Class code_pre extends Code {
     public function render($matches) {
 
         // first captured group is the tag name, i.e. the rendering variant
-        $variant = $matches[0];
+        $variant = isset($matches[0]) ? $matches[0] : 'snippet';
 
         // second captured group is the code to display, if any
         $text = isset($matches[1]) ? $matches[1] : '';
 
-        return Codes::render_pre($text, $variant);
+        $text = Codes::fix_tags($text);
+
+        // change new lines
+        $text = trim(str_replace("\r", '', str_replace(array("<br>\n", "<br/>\n", "<br />\n", '<br>', '<br/>', '<br />'), "\n", $text)));
+
+        // caught from tinymce
+        if(preg_match('/<p>(.*)<\/p>$/s', $text, $tags)) {
+            $text = $tags[1];
+            $text = str_replace(array('&amp;', '<p>', '</p>'), array('&', '', "\n"), $text);
+        }
+
+        // match some php code
+        $explicit = FALSE;
+        if(preg_match('/<\?php\s/', $text))
+            $variant = 'php';
+        elseif(($variant == 'php') && !preg_match('/<\?'.'php.+'.'\?'.'>/', $text)) {
+            $text = '<?'.'php'."\n".$text."\n".'?'.'>';
+            $explicit = TRUE;
+        }
+
+        // highlight php code, if any
+        if($variant == 'php') {
+
+            // fix some chars set by wysiwig editors
+            $text = str_replace(array('&lt;', '&gt;', '&nbsp;', '&quot;'), array('<', '>', ' ', '"'), $text);
+
+            // handle newlines and indentations properly
+            $text = str_replace(array("\n<span", "\n</code", "\n</pre", "\n</span"), array('<span', '</code', '</pre', '</span'), Safe::highlight_string($text));
+
+            // remove explicit php prefix and suffix -- dependant of highlight_string() evolution
+            if($explicit)
+                $text = preg_replace(array('/&lt;\?php<br\s*\/>/', '/\?&gt;/'), '', $text);
+
+        // or prevent html rendering
+        } else
+            $text = str_replace(array('<', "\n"), array('&lt;', '<br/>'), $text);
+
+        // prevent additional transformations
+        $search = array(	'[',		']',		':',		'//',			'##',			'**',			'++',			'--',			'__');
+        $replace = array(	'&#91;',	'&#93;',	'&#58;',	'&#47;&#47;',	'&#35;&#35;',	'&#42;&#42;',	'&#43;&#43;',	'&#45;&#45;',	'&#95;&#95;');
+        $output = '<pre>'.str_replace($search, $replace, $text).'</pre>';
+
+        return $output;
     }
 }
 ?>

--- a/codes/code_pre.php
+++ b/codes/code_pre.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * render [php]...[/php] and [snippet]...[/snippet] blocks
+ *
+ * These codes are pure PRESENTATION: they display a piece of code, either
+ * syntax-highlighted PHP ([php]) or a verbatim snippet ([snippet]), wrapped in
+ * a <pre> element. They do NOT execute anything -- unlike the former [execute]
+ * code that has been moved to codes/unused/.
+ *
+ * They are packaged as a movable extension so that a site which never displays
+ * code can drop this file into codes/unused/ (and delete codes/patterns.auto.php
+ * to force a rebuild) to spare two rendering passes on every piece of content.
+ *
+ * Ordering note: these codes MUST run early, right after [escape], so that the
+ * other codes do not alter the code being displayed (e.g. // ## [section=x] a
+ * URL or an e-mail address found inside the block). codes/codes.php loads this
+ * extension at that early point and the generic code_*.php scan skips it.
+ *
+ * The actual rendering lives in Codes::render_pre(), a shared utility also used
+ * outside the codes engine (scripts/browse.php); this class only binds the tags.
+ *
+ * @author Bernard Paques (rendering)
+ * @author Alexis Raimbault (extension mechanism)
+ * @reference
+ * @license http://www.gnu.org/copyleft/lesser.txt GNU Lesser General Public License
+ */
+Class code_pre extends Code {
+
+    var $patterns = array(
+        '/\[(php)\](.*?)\[\/php\]/is',              // [php]...[/php]
+        '/\[(snippet)\](.*?)\[\/snippet\]/is',      // [snippet]...[/snippet]
+    );
+
+    public function render($matches) {
+
+        // first captured group is the tag name, i.e. the rendering variant
+        $variant = $matches[0];
+
+        // second captured group is the code to display, if any
+        $text = isset($matches[1]) ? $matches[1] : '';
+
+        return Codes::render_pre($text, $variant);
+    }
+}
+?>

--- a/codes/codes.php
+++ b/codes/codes.php
@@ -1673,66 +1673,6 @@ Class Codes {
 	}
 
 	/**
-	 * render a block of code
-	 *
-	 * @param string the text
-	 * @return string the rendered text
-	**/
-	public static function render_pre($text, $variant='snippet') {
-            
-                $text = Codes::fix_tags($text);
-
-		// change new lines
-		$text = trim(str_replace("\r", '', str_replace(array("<br>\n", "<br/>\n", "<br />\n", '<br>', '<br/>', '<br />'), "\n", $text)));
-
-		// caught from tinymce
-		if(preg_match('/<p>(.*)<\/p>$/s', $text, $matches)) {
-			$text = $matches[1];
-			$text = str_replace(array('&amp;', '<p>', '</p>'), array('&', '', "\n"), $text);
-		}
-
-		// match some php code
-		$explicit = FALSE;
-		if(preg_match('/<\?php\s/', $text))
-			$variant = 'php';
-		elseif(($variant == 'php') && !preg_match('/<\?'.'php.+'.'\?'.'>/', $text)) {
-			$text = '<?'.'php'."\n".$text."\n".'?'.'>';
-			$explicit = TRUE;
-		}
-
-		// highlight php code, if any
-		if($variant == 'php') {
-
-			// fix some chars set by wysiwig editors
-			$text = str_replace(array('&lt;', '&gt;', '&nbsp;', '&quot;'), array('<', '>', ' ', '"'), $text);
-
-			// wrap long lines if necessary
-// 			$lines = explode("\n", $text);
-// 			$text = '';
-// 			foreach($lines as $line)
-// 				$text .= wordwrap($line, 100, " \n", 0)."\n";
-
-			// handle newlines and indentations properly
-			$text = str_replace(array("\n<span", "\n</code", "\n</pre", "\n</span"), array('<span', '</code', '</pre', '</span'), Safe::highlight_string($text));
-
-			// remove explicit php prefix and suffix -- dependant of highlight_string() evolution
-			if($explicit)
-				$text = preg_replace(array('/&lt;\?php<br\s*\/>/', '/\?&gt;/'), '', $text);
-
-		// or prevent html rendering
-		} else
-			$text = str_replace(array('<', "\n"), array('&lt;', '<br/>'), $text);
-
-		// prevent additional transformations
-		$search = array(	'[',		']',		':',		'//',			'##',			'**',			'++',			'--',			'__');
-		$replace = array(	'&#91;',	'&#93;',	'&#58;',	'&#47;&#47;',	'&#35;&#35;',	'&#42;&#42;',	'&#43;&#43;',	'&#45;&#45;',	'&#95;&#95;');
-		$output = '<pre>'.str_replace($search, $replace, $text).'</pre>';
-
-		return $output;
-
-	}
-
-	/**
 	 * render a compact list of recent publications
 	 *
 	 * The provided anchor can reference:

--- a/codes/codes.php
+++ b/codes/codes.php
@@ -590,8 +590,16 @@ Class Codes {
                         $patterns_map['|</h(\d)>\n+|i']                                             = '</h$1>'                  ;  // strip \n after title
                         $patterns_map['/\n[ \t]*(From|To|cc|bcc|Subject|Date):(\s*)/i']             = BR.'$1:$2'                ;  // common message headers
                         $patterns_map['/\[escape\](.*?)\[\/escape\]/is']                            = 'Codes::render_escaped'   ;  // [escape]...[/escape] (before everything)
-                        $patterns_map['/\[php\](.*?)\[\/php\]/is']                                  = 'Codes::render_pre_php'   ;  // [php]...[/php]
-                        $patterns_map['/\[snippet\](.*?)\[\/snippet\]/is']                          = 'Codes::render_pre'       ;  // [snippet]...[/snippet]
+                        // [php]/[snippet] live in the movable extension codes/code_pre.php but
+                        // MUST run early (right after [escape]) to protect displayed code from
+                        // the other codes -- so load it here, not through the generic scan below.
+                        // Move code_pre.php to codes/unused/ (and delete patterns.auto.php) to disable.
+                        if(Safe::filesize('codes/code_pre.php')) {
+                                include_once $context['path_to_root'].'codes/code_pre.php';
+                                $pre = new code_pre();
+                                $pre->get_pattern($patterns_map);
+                                unset($pre);
+                        }
                         $patterns_map['/(\[page\].*)$/is']                                          = ''                        ;  // [page] (provide only the first one)
                         $patterns_map['/\[(associate|member|anonymous|hidden|restricted|authenticated)\](.*?)\[\/\1\]/is']  = 'Codes::render_hidden'    ;  // [associate]...[/associate] 
                         $patterns_map['/\[redirect=([^\]]+?)\]/is']                                 = 'Codes::render_redirect'  ;  // [redirect=<link>]
@@ -670,9 +678,14 @@ Class Codes {
 				  //get file only begining with code_
 				  if (!(substr($file,0,5)==='code_'))
 					continue;
-                                  
+
                                   // skip .bak files
                                   if (substr($file,-4)==='.bak')
+                                        continue;
+
+                                  // code_pre is loaded early (see above) to keep [php]/[snippet]
+                                  // ahead of the other codes -- do not register it a second time
+                                  if ($file === 'code_pre.php')
                                         continue;
 
 				  include_once($dir.$file);
@@ -1718,16 +1731,6 @@ Class Codes {
 		return $output;
 
 	}
-        
-        /**
-         * render [php]...[php] code
-         * 
-         * @param string $text
-         * @return string the formatted block
-         */
-        public static function render_pre_php($text) {
-            return Codes::render_pre($text,'php');
-        }
 
 	/**
 	 * render a compact list of recent publications

--- a/scripts/browse.php
+++ b/scripts/browse.php
@@ -86,8 +86,16 @@ else {
 	// protect from spammers and robots
 	$content = preg_replace('/\[email\].+\[\/email\]/i', '', $content);
 
-	// highlight php code
-	$context['text'] .= "\n".Codes::render_pre($content);
+	// highlight php code -- rendering lives in the movable extension codes/code_pre.php
+	if(Safe::filesize('codes/code_pre.php')) {
+		include_once $context['path_to_root'].'codes/code_pre.php';
+		$code = new code_pre();
+		$context['text'] .= "\n".$code->render(array('snippet', $content));
+		unset($code);
+
+	// the extension has been disabled -- display the script verbatim
+	} else
+		$context['text'] .= "\n".'<pre>'.str_replace('<', '&lt;', $content).'</pre>';
 
 	// menu bar for reference scripts
 	if($content && ($store == 'reference')) {


### PR DESCRIPTION
…xtension

[php] and [snippet] are pure presentation (syntax-highlighted <pre>); they do not execute anything. Package them as a code_* extension so a site that never displays code can move it to codes/unused/ (after deleting patterns.auto.php) to spare two rendering passes.

They must keep running early (right after [escape]) so the other codes do not alter the code being displayed, whereas the generic code_*.php scan appends extensions last. So codes.php loads code_pre.php at that early point and the generic scan skips it. Codes::render_pre() stays in place (also used by scripts/browse.php); the now-dead render_pre_php wrapper is removed.