### PR TITLE
fix: build self_url from REQUEST_URI to avoid canonical redirect loops

### DIFF
--- a/shared/global.php
+++ b/shared/global.php
@@ -383,12 +383,14 @@ $context['url_to_master'] = 'http' . (($is_https)?'s':'') . '://' . $context['ma
 
 // the url to reference ourself, including query string -- copy of the reference submitted by user agent (i.e., before rewritting)
 $context['self_url'] = '';
-if(isset($_SERVER['SCRIPT_URI']) && isset($_SERVER['QUERY_STRING']))
+// REQUEST_URI is always the original, un-rewritten request -- prefer it over SCRIPT_URI, which
+// some hosts (e.g. OVH) populate with the internally-rewritten target and would break canonical URL checks
+if(isset($_SERVER['REQUEST_URI'])) // this includes the query string
+	$context['self_url'] = $context['url_to_home'].$_SERVER['REQUEST_URI'];
+elseif(isset($_SERVER['SCRIPT_URI']) && isset($_SERVER['QUERY_STRING']))
 	$context['self_url'] = $_SERVER['SCRIPT_URI'].'?'.$_SERVER['QUERY_STRING'];
 elseif(isset($_SERVER['SCRIPT_URI']))
 	$context['self_url'] = $_SERVER['SCRIPT_URI'];
-elseif(isset($_SERVER['REQUEST_URI'])) // this includes query string
-	$context['self_url'] = $context['url_to_home'].$_SERVER['REQUEST_URI'];
 
 // recombine the self_url (to keep only the essencial)
 $scheme = parse_url($context['self_url'], PHP_URL_SCHEME);


### PR DESCRIPTION
On hosts where mod_rewrite populates $_SERVER['SCRIPT_URI'] with the internally-rewritten target (e.g. OVH) instead of the original request, $context['self_url'] no longer matched the friendly permalink returned by get_permalink(). With friendly URLs enabled (with_friendly_urls='R'), the canonical re-enforcement in articles/view.php and sections/view.php then issued an endless 301 loop on every non-cached article/section view.

REQUEST_URI always carries the original, un-rewritten request (as the code comment already assumes: "before rewritting"), so prefer it over SCRIPT_URI.