### PR TITLE
fix: sanitize fulltext boolean patterns to keep operators out of MATC…

### DIFF
--- a/search.php
+++ b/search.php
@@ -76,33 +76,8 @@ if(!defined('MINIMUM_TOKEN_SIZE'))
 	define('MINIMUM_TOKEN_SIZE', 4);
 
 // kill short and redundant tokens; adapt to boolean search
-$boolean_search = '';
-$tokens = preg_split('/[\s,]+/', $search);
-if(@count($tokens)) {
-	foreach($tokens as $token) {
-
-		// too short
-		if(strlen(preg_replace('/&.+?;/', 'x', $token)) < MINIMUM_TOKEN_SIZE)
-			continue;
-
-		// already here (repeated word)
-		if(strpos($boolean_search, $token) !== FALSE)
-			continue;
-
-		// re-enforce boolean mode
-		if(($token[0] != '+') && ($token[0] != '+') && ($token[0] != '~'))
-			$token = '+'.$token;
-
-		// keep this token
-		$boolean_search .= $token.' ';
-	}
-	if(!empty($boolean_search)) {
-		$boolean_search = trim($boolean_search).'*';
-	} else {
-		// Si aucun terme valide, on ne fait pas de recherche FULLTEXT
-		$boolean_search = '';
-	}
-}
+// an empty string means that no fulltext search will take place
+$boolean_search = SQL::boolean_pattern($search, MINIMUM_TOKEN_SIZE);
 
 // load localized strings
 i18n::bind('root');

--- a/shared/sql.php
+++ b/shared/sql.php
@@ -256,6 +256,66 @@ Class SQL {
 	}
 
 	/**
+	 * build a safe pattern for a fulltext search in boolean mode
+	 *
+	 * Characters '+', '-', '<', '>', '(', ')', '~', '*', '"' and '@' are operators of the
+	 * boolean fulltext parser. When one of them shows up inside a word -- e.g., the '@' of
+	 * an e-mail address -- the parser stops on a syntax error, and the database rejects the
+	 * whole query. Therefore we keep the operator explicitly typed at the beginning of a
+	 * token, if any, and we turn every other operator into a token separator.
+	 *
+	 * A trailing wildcard is appended to the resulting pattern, to allow for auto-completion.
+	 *
+	 * @param string the search string, as typed by the surfer
+	 * @param int the minimum size of tokens to consider, if any
+	 * @return string a pattern suitable for IN BOOLEAN MODE, or an empty string
+	 */
+	public static function boolean_pattern($text, $minimum_token_size=0) {
+
+		// sanity check
+		if(!is_string($text) || !$text = trim($text))
+			return '';
+
+		// operators of the boolean fulltext parser
+		$operators = '/['.preg_quote('+-<>()~*"@', '/').']+/';
+
+		$pattern = '';
+		foreach(preg_split('/[\s,]+/', $text, -1, PREG_SPLIT_NO_EMPTY) as $token) {
+
+			// preserve the operator explicitly typed by the surfer, if any
+			$operator = '+';
+			if(strpos('+-~', $token[0]) !== FALSE) {
+				$operator = $token[0];
+				$token = substr($token, 1);
+			}
+
+			// remaining operators are separators, and one token may yield several words
+			$token = preg_replace($operators, ' ', $token);
+
+			foreach(preg_split('/\s+/', $token, -1, PREG_SPLIT_NO_EMPTY) as $word) {
+
+				// too short to be indexed
+				if(strlen(preg_replace('/&.+?;/', 'x', $word)) < $minimum_token_size)
+					continue;
+
+				// already here (repeated word)
+				if(strpos($pattern, $word) !== FALSE)
+					continue;
+
+				// keep this word
+				$pattern .= $operator.$word.' ';
+			}
+		}
+
+		// no word has survived
+		if(!$pattern = trim($pattern))
+			return '';
+
+		// allow for auto-completion
+		return $pattern.'*';
+	}
+
+	/**
 	 * fetch next result as an associative array
 	 *
 	 * @param resource set of rows or standard array

--- a/users/users.php
+++ b/users/users.php
@@ -2335,27 +2335,14 @@ Class Users {
 			return $output;
 		}
 
-		// make it a proper boolean search
-		if($pattern[0] != '+') {
+		// make it a proper boolean search, if it has not been prepared already
+		if($pattern[0] != '+')
+			$pattern = SQL::boolean_pattern($pattern);
 
-			$tokens = preg_split('/[\s,]+/', $pattern);
-			if(@count($tokens)) {
-				$pattern = '';
-				foreach($tokens as $token) {
-
-					// already here (repeated word)
-					if(strpos($pattern, $token) !== FALSE)
-						continue;
-
-					// re-enforce boolean mode
-					if(($token[0] != '+') && ($token[0] != '+') && ($token[0] != '~'))
-						$token = '+'.$token;
-
-					// keep this token
-					$pattern .= $token.' ';
-				}
-				$pattern = trim($pattern).'*';
-			}
+		// no word can be searched for
+		if(!$pattern) {
+			$output = NULL;
+			return $output;
 		}
 
 		// limit the scope of the request


### PR DESCRIPTION
…H ... AGAINST

The tokenizer prefixes every token with '+' and appends a wildcard, so an e-mail address typed as a login or in the search form yields a pattern such as '+john.doe@example.com*'. Characters '@', '-', '<', '>', '(', ')', '~', '*' and '"' are operators of the boolean fulltext parser: met inside a word, they abort the parse, and the database rejects the whole query.

Factor the tokenizer -- so far duplicated in search.php and Users::search() -- into SQL::boolean_pattern(). It keeps the operator explicitly typed at the beginning of a token, turns every other operator into a token separator, and skips empty tokens.

This also fixes a test on ($token[0] != '+') written twice, where the second one had to be '-', and an access to $token[0] on an empty token.