### PR TITLE
fix: restore the return-value error mode of mysqli (PHP 8.1 reports e…

### DIFF
--- a/shared/sql.php
+++ b/shared/sql.php
@@ -49,6 +49,12 @@ Class SQL {
 		// no resource yet
 		$handle = FALSE;
 
+		// since PHP 8.1 mysqli reports errors as exceptions, and the '@' operator does not
+		// suppress them -- yet this library checks return values and SQL::errno() instead,
+		// therefore we restore the historical behaviour of the driver
+		if(is_callable('mysqli_report'))
+			mysqli_report(MYSQLI_REPORT_OFF);
+
 		// regular connection --mask warning that popups in safe mode
 		if(is_callable('mysqli_connect'))
 			$handle = @mysqli_connect($host, $user, $password, $database);


### PR DESCRIPTION
…xceptions)

Since PHP 8.1 the mysqli driver defaults to MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT, hence it throws mysqli_sql_exception instead of returning FALSE. This library checks return values and SQL::errno() instead, therefore its error handling has become dead code, and the '@' operator that guards mysqli_connect() and the sentinel queries of SQL::ping() does not suppress exceptions.

As a result a database that cannot be reached no longer yields the page 'No access to the database server', but an uncaught exception. Restore the historical behaviour of the driver, so that SQL::connect(), SQL::ping() and SQL::query() report failures the way the rest of the code expects.