### PR TITLE
Fix broken sub-list pagination on category/section/article/user views

### DIFF
--- a/articles/view.php
+++ b/articles/view.php
@@ -180,8 +180,10 @@ if($render_overlaid)
 
 // view.php/12/nick name induces no particular processing
 
-// sanity check
-if(!is_int($zoom_index) || $zoom_index < 1)
+// sanity check -- $zoom_index comes as a string ('2') from the URL or $_REQUEST,
+// so is_int() was always false and every page was reset to 1; cast before testing
+$zoom_index = intval($zoom_index);
+if($zoom_index < 1)
 	$zoom_index = 1;
 
 // get the item from the database

--- a/categories/view.php
+++ b/categories/view.php
@@ -123,8 +123,10 @@ elseif(isset($context['arguments'][1]) && isset($context['arguments'][2])) {
 	$zoom_index = $context['arguments'][2];
 }
 
-// sanity check
-if(!is_int($zoom_index) || $zoom_index < 1)
+// sanity check -- $zoom_index comes as a string ('2') from the URL or $_REQUEST,
+// so is_int() was always false and every page was reset to 1; cast before testing
+$zoom_index = intval($zoom_index);
+if($zoom_index < 1)
 	$zoom_index = 1;
 
 // get the item from the database

--- a/sections/view.php
+++ b/sections/view.php
@@ -208,8 +208,10 @@ elseif(isset($context['arguments'][1]) && isset($context['arguments'][2])) {
 	$zoom_index = $context['arguments'][2];
 }
 
-// sanity check
-if(!is_int($zoom_index) || $zoom_index < 1)
+// sanity check -- $zoom_index comes as a string ('2') from the URL or $_REQUEST,
+// so is_int() was always false and every page was reset to 1; cast before testing
+$zoom_index = intval($zoom_index);
+if($zoom_index < 1)
 	$zoom_index = 1;
 
 // get the item from the database

--- a/users/view.php
+++ b/users/view.php
@@ -136,8 +136,10 @@ if(isset($_REQUEST['map']) && $_REQUEST['map'] == 'Y')
 global $render_overlaid;
 $whole_rendering = !$render_overlaid;
 
-// sanity check
-if(!is_int($zoom_index) || $zoom_index < 1)
+// sanity check -- $zoom_index comes as a string ('2') from the URL or $_REQUEST,
+// so is_int() was always false and every page was reset to 1; cast before testing
+$zoom_index = intval($zoom_index);
+if($zoom_index < 1)
 	$zoom_index = 1;
 
 // get the item from the database


### PR DESCRIPTION
$zoom_index is read from the URL path or $_REQUEST as a string ('2'), so the guard `if(!is_int($zoom_index) ...)` was always true and reset every page to 1. Any page beyond the first (sub-categories, related articles, comments, files, links, users) silently showed page 1.

Cast to int with intval() before the range check, in the four affected view scripts.
