### PR TITLE
fix: avoid spurious error log for fusion overlay generic text variants

### DIFF
--- a/overlays/fusion.php
+++ b/overlays/fusion.php
@@ -418,20 +418,23 @@ Class Fusion extends Overlay {
 	 * @return some HTML to be inserted into the resulting page
 	 */
 	function get_text($variant='view', $host=NULL) {
-            
-            // standard behaviour
-            $text = parent::get_text($variant, $host);
-            
-            // try something else if nothing founded
-            if($text === null) {
-                
-                // look for specific function get_<variant>_text
-                $text = $this->fusion_first_reply('get_'.$variant.'_text', array($host));
-                
+
+            // native variants, or a function defined by the fusion itself
+            $func = 'get_'.$variant.'_text';
+            if(in_array($variant, array('description', 'introduction', 'title')) || is_callable(array($this, $func))) {
+                $text = parent::get_text($variant, $host);
+                return $text;
             }
-            
+
+            // else look for the specific function within merged overlays
+            $text = $this->fusion_first_reply($func, array($host));
+
+            // complain only when no merged overlay replied
+            if($text === null)
+                Logger::error(sprintf(i18n::s('function %s not found for overlay %s'), $func, get_class($this)));
+
             return $text;
-            
+
         }
         
         /**


### PR DESCRIPTION
Overlay::get_text() logs an error whenever the default case does not find a get_<variant>_text method on $this. Fusion::get_text() called parent::get_text() unconditionally before falling back to merged overlays via fusion_first_reply(), so every generic variant handled only by a merged overlay (not by Fusion itself) logged a spurious "function not found" error on every render.

Only delegate to parent::get_text() for the native variants it owns (description/introduction/title, backed by Fusion's own get_live_*() methods) or when Fusion defines the variant method itself. Otherwise go straight to fusion_first_reply() and log only when no merged overlay replies either.
