### PR TITLE
fix: check_unused.php fatals on PHP 8 -- $output must be an array

### DIFF
--- a/users/check_unused.php
+++ b/users/check_unused.php
@@ -37,8 +37,9 @@ if(Surfer::is_crawler()) {
 	die(i18n::s('You are not allowed to perform this operation.'));
 }
 
-// we return some text
-$output = '';
+// we return a JSON object -- must be an array, writing string offsets
+// like $output['can'] on a string is a fatal error since PHP 8.0
+$output = array();
 
 // check syntax
 $syntax = TRUE;
@@ -63,7 +64,7 @@ if($syntax) {
     }
 
     $query = "SELECT id FROM ".SQL::table_name('users')." WHERE ".$searchin
-            ." = '".$searchfor."'";
+            ." = '".SQL::escape($searchfor)."'";
 
     $found = SQL::query_first($query);
 


### PR DESCRIPTION
$output was initialized as an empty string, then written to with string offsets ($output['can'], $output['message']). Old PHP versions silently converted the empty string to an array; since PHP 8.0 this throws 'Cannot access offset of type string on string', so the nick name / email availability AJAX check dies with an empty response.

Also escape the searched value in the SQL query.