### PR TITLE
fix: close output buffer in finalize_page() to keep Content-Length in…

### DIFF
--- a/shared/global.php
+++ b/shared/global.php
@@ -1733,8 +1733,12 @@ function finalize_page($no_return=FALSE) {
 	// don't stop even if the browser connection dies
 	Safe::ignore_user_abort(TRUE);
         
-        // send page
-        ob_flush();
+        // send page -- close our buffer instead of only flushing it, else the
+        // handler is called again with an empty string at shutdown and, when
+        // php.ini output_buffering is on, overrides Content-Length with 0,
+        // which makes the web server truncate small responses (AJAX, JSON)
+        if(ob_get_level())
+            ob_end_flush();
 
 	// statistics, etc...
 	Hooks::include_scripts('finalize');


### PR DESCRIPTION
…tact

finalize_page() used ob_flush(), which flushes the yacs_handler buffer without closing it. At exit time PHP performs a final flush of the still-active buffer, so yacs_handler() is called a second time with an empty string. When php.ini output_buffering is enabled (cPanel default 4096), headers are still held by the outer buffer at that point, so headers_sent() is FALSE and the handler overrides the correct Content-Length header with 'Content-Length: 0'. The web server then truncates the response body to zero bytes.

Only responses smaller than the output_buffering size are affected -- larger ones (e.g. RSS feeds) force headers out mid-stream and are immune. Typical victims are the JSON AJAX endpoints going through render_raw() + finalize_page(): users/complete.php (name autocompletion returns an empty body, killing the jQuery UI autocomplete silently), categories/complete.php, users/check_unused.php, comments/thread.php.

Use ob_end_flush() to flush and close the buffer in one step, so the handler runs exactly once with the full content.