### PR TITLE
fix: avoid passing null to mb_strtolower() in delete confirmations

### DIFF
--- a/articles/delete.php
+++ b/articles/delete.php
@@ -142,8 +142,8 @@ else {
 	$menu = array();
         
         $class_submit   = ( $render_overlaid )?'submit-overlaid':'button';
-        if(is_object($overlay))
-             $delete_text    = mb_strtolower($overlay->get_label('delete_command'));
+        if(is_object($overlay) && ($delete_text = $overlay->get_label('delete_command')))
+             $delete_text = mb_strtolower($delete_text);
   
         if(!isset($delete_text)) $delete_text = i18n::s('delete this page');
 

--- a/files/delete.php
+++ b/files/delete.php
@@ -147,8 +147,10 @@ else {
         
         $class_submit   = ( $render_overlaid )?'submit-overlaid':'button';
         
-        if(!is_object($overlay) || !$delete_text = mb_strtolower($overlay->get_label('delete_command')))
+        if(!is_object($overlay) || !($delete_text = $overlay->get_label('delete_command')))
              $delete_text = i18n::s('delete this file');
+        else
+             $delete_text = mb_strtolower($delete_text);
         
 	$menu[] = Skin::build_submit_button(sprintf(i18n::s('Yes, I want to %s'),$delete_text), NULL, NULL,  'confirmed', $class_submit);
         if(!$render_overlaid) {


### PR DESCRIPTION
Overlay::get_label('delete_command') returns null by default (and in most overlays), which triggered a "Passing null to parameter #1 of type string is deprecated" notice under PHP 8.1+ in articles/delete.php and files/delete.php. The label is now lowercased only when non-empty, which also fixes a latent bug where an empty overlay label produced an empty delete command instead of falling back to the localized default.