### PR TITLE
fix: honour publication and expiry dates of the cover page

### DIFF
--- a/index.php
+++ b/index.php
@@ -235,6 +235,23 @@ if( (!isset($context['root_cover_at_home']) || ($context['root_cover_at_home'] !
 	elseif($anchor = Sections::lookup('covers'))
 		$cover_page = Articles::get_newest_for_anchor($anchor);
 
+	// a page named 'cover' is fetched as-is, while Articles::get_newest_for_anchor()
+	// does filter on publication and expiry dates. Apply the very same rules here, so
+	// that both ways of providing a cover page behave alike.
+	if(isset($cover_page['id'])) {
+
+		// not published yet, or still a draft
+		if(!isset($cover_page['publish_date']) || ($cover_page['publish_date'] <= NULL_DATE)
+			|| ($cover_page['publish_date'] > $context['now']))
+			$cover_page = NULL;
+
+		// past its expiry date
+		elseif(isset($cover_page['expiry_date']) && ($cover_page['expiry_date'] > NULL_DATE)
+			&& ($cover_page['expiry_date'] <= $context['now']))
+			$cover_page = NULL;
+
+	}
+
 	// compute page title -- $context['page_title']
 	if(isset($cover_page['title']) && (!isset($context['root_cover_at_home']) || ($context['root_cover_at_home'] == 'full')))
 		$context['page_title'] = $cover_page['title'];


### PR DESCRIPTION
index.php looks for the cover page in two ways, and they do not behave alike. Articles::get_newest_for_anchor(), used when a 'covers' section exists, filters on both the publication and the expiry dates. But Articles::get('cover'), used when a page is simply named 'cover', is a plain fetch: the page is displayed on the front page whatever its state.

So, on a site using a named cover page:

- setting the page back to draft does not remove it from the front page
- giving it an expiry date has no effect either

Every other listing in articles/articles.php filters expiry_date (see the "only consider live articles" clause), which makes the cover the single exception.

Apply the same two rules to the named page, using the idioms already found in articles/articles.php, so that both ways of providing a cover behave the same. The check is placed before the page title is computed, so that an expired cover does not leak its title either.

The 'active' field is deliberately left alone: whether a restricted cover should still be shown to members is a product decision rather than a defect, and is better discussed separately.
