### PR TITLE
fix: restore FontAwesome outline icons and drop leftover fa4 names

### DIFF
--- a/control/configure.php
+++ b/control/configure.php
@@ -1007,7 +1007,7 @@ if(!Surfer::is_associate()) {
         if(isset($_REQUEST['with_debug']) && $_REQUEST['with_debug'] === 'N' && Js_css::check_production_libs()) {
             
             
-            $context['text'] .= tag::_('p','',fa::_('warning').'&nbsp;'.i18n::s('You are in production mode and Yacs detected that compressed javascript libs do not exist or are out of date'));
+            $context['text'] .= tag::_('p','',fa::_('exclamation-triangle').'&nbsp;'.i18n::s('You are in production mode and Yacs detected that compressed javascript libs do not exist or are out of date'));
             
             // route to /tools/jsmin.php
             $context['followup_link']   = 'tools/jsmin.php';

--- a/included/font_awesome/fa.php
+++ b/included/font_awesome/fa.php
@@ -19,7 +19,8 @@ Class fa {
      * 
      * examples :
      * fa::_('camera-retro', '3x')
-     * fa::_('circle-o-notch', '3x spin', 'Loading...', true);
+     * fa::_('circle-notch', '3x spin', 'Loading...', true);
+     * fa::_('square', 'regular')            // outline variant, .far
      * 
      * @param string $icon choosen to be displayed. You must at least provide that.
      * @see http://fontawesome.io/icons/ for a list
@@ -44,6 +45,15 @@ Class fa {
             $main_prefix .= 'b';
             $options = str_replace('brand', '', $options);
             
+        }
+        
+        // if we have regular option, use .far and remove regular from option
+        // since FontAwesome 5 the family is carried by the prefix : .fa (alias
+        // of .fas) is solid, .far is the outline variant. Without this, outline
+        // icons such as the former fa4 'square-o' cannot be expressed at all.
+        elseif(str_contains($options, 'regular')) {
+            $main_prefix .= 'r';
+            $options = str_replace('regular', '', $options);
         }
         
         // case icon name begin with "fa"

--- a/shared/js_css.php
+++ b/shared/js_css.php
@@ -156,6 +156,7 @@ Class Js_Css {
             if($knacss)         $import .= '@import "knacss.scss";';
             if($fontawesome)    $import .= '@import "fontawesome.scss";';
             if($fontawesome)    $import .= '@import "solid.scss";';             // fontawesome solid icon set
+            if($fontawesome)    $import .= '@import "regular.scss";';           // fontawesome outline icon set (.far)
             if($yacss)          $import .= '@import "variables.scss";';
             if($yacss)          $import .= '@import "yacss.scss";';
  

--- a/skins/skin_skeleton.php
+++ b/skins/skin_skeleton.php
@@ -4597,7 +4597,7 @@ Class Skin_Skeleton {
 
                 if(!defined('PRIVATE_FLAG'))
 			define('PRIVATE_FLAG', tag::_span(
-                                fa::_('square-o','stack-2x /private')
+                                fa::_('square','stack-2x regular /private')
                                 .fa::_('eye','stack-1x /private', (is_callable(array('i18n', 's')))? i18n::s('private') : 'private' )
                                 ,'/fa-stack /flag'));
 
@@ -4611,7 +4611,7 @@ Class Skin_Skeleton {
 		// the bullet used to signal restricted pages
 		if(!defined('RESTRICTED_FLAG'))
 			define('RESTRICTED_FLAG', tag::_span(
-                                fa::_('square-o','stack-2x /restricted')
+                                fa::_('square','stack-2x regular /restricted')
                                 .fa::_('eye','stack-1x /restricted', (is_callable(array('i18n', 's')))? i18n::s('restricted') : 'restricted' )
                                 ,'/fa-stack /flag'));
 
@@ -4633,7 +4633,7 @@ Class Skin_Skeleton {
 
 		// the HTML used to signal sticky pages
 		if(!defined('STICKY_FLAG'))
-			define('STICKY_FLAG', fa::_('thumb-tack','/sticky /flag'));
+			define('STICKY_FLAG', fa::_('thumbtack','/sticky /flag'));
 
 		// the HTML string appended to each item of the site bar
 		if(!defined('TABS_ITEM_SUFFIX'))
@@ -4668,7 +4668,7 @@ Class Skin_Skeleton {
 
 		// the bullet used to signal updated pages
                 if(!defined('UPDATED_FLAG'))
-			define('UPDATED_FLAG', '&nbsp;'.fa::_('refresh','/updated /flag', (is_callable(array('i18n', 's')))? i18n::s('updated') : 'updated' ));
+			define('UPDATED_FLAG', '&nbsp;'.fa::_('sync','/updated /flag', (is_callable(array('i18n', 's')))? i18n::s('updated') : 'updated' ));
 
 		// the maximum number of users attached to an anchor -- see sections/select.php
 		if(!defined('USERS_LIST_SIZE'))


### PR DESCRIPTION
The bundled package is FontAwesome Free 5.15.4, yet a few fa::_() calls still name icons the way fa4 did. Those names no longer resolve, and the icon comes out empty, silently.

Since fa5 the family is carried by the prefix, not by the name -- 'square-o' became 'far fa-square'. fa::_() had no way to express that: only the 'brand' option was mapped, to .fab. Hence a symmetric 'regular' option, mapping to .far.

That prefix alone was not enough, though. _core.scss declares the .far selector, but the matching @font-face lives in regular.scss, which no one imports -- fontawesome.scss pulls core through brands, and js_css.php only added solid.scss. The whole outline family was therefore inert, although its webfonts ship with the package. Importing regular.scss costs about 850 bytes of css, and the woff2 is only fetched when an .far icon is actually rendered.

Renamed accordingly:
  square-o    -> square + regular    skins/skin_skeleton.php  (PRIVATE_FLAG, RESTRICTED_FLAG)
  thumb-tack  -> thumbtack           skins/skin_skeleton.php  (STICKY_FLAG)
  refresh     -> sync                skins/skin_skeleton.php  (UPDATED_FLAG)
  warning     -> exclamation-triangle  control/configure.php

Note that fa5 Free only ships 151 icons in the regular family, against 1001 in solid: the outline variant does not exist for most icons. The four names above were checked against webfonts/fa-regular-400.svg.
