### PR TITLE
fix: escape tag attribute values for HTML/XML, not for PHP strings

### DIFF
--- a/skins/tag.php
+++ b/skins/tag.php
@@ -117,10 +117,10 @@ class tag {
             if(!$name) return $attribute;
             
             // do it
-            $attribute .= ' '.$name.'="'.addslashes($value).'"';
-            
+            $attribute .= ' '.$name.'="'.htmlspecialchars($value, ENT_QUOTES, 'UTF-8').'"';
+
             return $attribute;
-            
+
         }
         
         /**
@@ -141,8 +141,8 @@ class tag {
             if(!$name) return $attribute;
             
             // do it
-            $attribute .= ' data-'.$name.'="'.addslashes($value).'"';
-        
+            $attribute .= ' data-'.$name.'="'.htmlspecialchars($value, ENT_QUOTES, 'UTF-8').'"';
+
             return $attribute;
         }
     


### PR DESCRIPTION
tag::_attr() and tag::_data() built the attribute value with addslashes(), which escapes a double quote as \" -- the PHP/JS string escaping convention, not an HTML or XML entity. A backslash has no special meaning to an HTML/XML parser: it reads it as a literal character, then the following " still closes the attribute early, corrupting the rest of the tag.

tag::_attr('title', 'Version "adaptée"') produced
title="Version \"adaptée\"" instead of a self-contained attribute.

Switch both to htmlspecialchars($value, ENT_QUOTES, 'UTF-8'), matching how attribute values are escaped everywhere else in the core. Checked all 25 call sites of tag::_attr()/tag::_data(): none relies on addslashes()'s string-escaping semantics (no JS event handler attributes among them), so this is a drop-in fix.