### PR TITLE
fix: do not set Content-Length when yacs_handler does not compress

### DIFF
--- a/shared/global.php
+++ b/shared/global.php
@@ -1755,7 +1755,8 @@ function finalize_page($no_return=FALSE) {
  * This handler is able:
  * - to transcode data to another character set
  * - to compress data, if asked for it
- * - to set the Content-Length HTTP header
+ * - to set the Content-Length HTTP header, but only when it does compress the
+ *   data itself, since it is then the last stage to change the body
  *
  * We have it because the standard 'ob_gzhandler' does not set the Content-Length header properly.
  * Also, this function transcodes char to valid Unicode if necessary.
@@ -1825,12 +1826,14 @@ function yacs_handler($content) {
 	else
 		$compress = TRUE;
 
-	// send plain data
-	if(!$compress) {
-		if(!headers_sent())
-			Safe::header('Content-Length: '.strlen($content));
+	// send plain data -- do not set Content-Length here: a downstream filter
+	// (mod_deflate, mod_brotli, a caching proxy) may compress or transform the
+	// body afterwards, while this header would survive untouched and announce
+	// the uncompressed size. The user agent then waits for bytes that never
+	// come, until the stream is reset. Without the header the web server falls
+	// back to chunked encoding or to a connection close, both of them correct.
+	if(!$compress)
 		return $content;
-	}
 
 	// compress data
 	$data = gzcompress($content, 5);


### PR DESCRIPTION
yacs_handler() sets Content-Length with the size of the buffer it is about to return, even when it returns plain, uncompressed data. That header is only correct if nothing changes the body afterwards.

When the web server compresses the response itself -- Apache with mod_deflate is the common case, and it is exactly the configuration the 'Do not try to compress transmitted data. The web engine already does it.' option is meant for -- the body sent on the wire is smaller than the announced length, but the header set by PHP survives the filter. The user agent receives and renders the whole page, then keeps waiting for the bytes it was promised until the stream is reset. Measured on a live site behind mod_deflate: content-length 16231, 5356 bytes actually received, first byte at 0.117 s, connection reset after 5.12 s.

Drop the header on that path. The web server then falls back to chunked transfer encoding or to closing the connection, both of which are valid and let the user agent know where the body ends. The compressing path is unchanged: there yacs_handler is the last stage to touch the body, so the length it computes is the one transmitted.

Same header, same handler, and the same family of bug as commit "fix: close the output buffer in finalize_page" (PR #74).