### PR TITLE
fix: serve each surfer his own site map, and restore its pagination

### DIFF
--- a/articles/index.php
+++ b/articles/index.php
@@ -92,8 +92,11 @@ if(($page > 1) && (($page - 1) * $items_per_page > $stats['count'])) {
 		$context['page_menu'] += Skin::navigate($home, $prefix, $stats['count'], $items_per_page, $page);
 	}
 
-	// page main content
+	// page main content -- the listing below is extended to pages managed by
+	// this surfer, which Cache::put() does not discriminate on its own
 	$cache_id = 'articles/index.php#text#'.$page;
+	if($signature = Surfer::get_assignment_signature())
+		$cache_id .= '#'.$signature;
 	if(!$text = Cache::get($cache_id)) {
 
 		// query the database and layout that stuff

--- a/sections/index.php
+++ b/sections/index.php
@@ -51,9 +51,9 @@
  * Use this hook to include any text right after the main content.
  *
  * Accept following invocations:
- * - index.php (view the 20 top sections)
- * - index.php/2 (view sections 41 to 60)
- * - index.php?page=2 (view sections 41 to 60)
+ * - index.php (view the 50 top sections)
+ * - index.php/2 (view sections 51 to 100)
+ * - index.php?page=2 (view sections 51 to 100)
  *
  * @author Bernard Paques
  * @author GnapZ
@@ -74,10 +74,6 @@ else
 	$page = 1;
 $page = max(1,intval($page));
 
-// sanity check
-if($page < 1)
-	$page = 1;
-
 // load the skin
 load_skin('site_map');
 
@@ -87,8 +83,8 @@ $items_per_page = 50;
 // the title of the page
 $context['page_title'] = i18n::s('Site map');
 
-// count public root sections in the database
-$count = Sections::count_for_anchor(NULL);
+// count root sections that are listed below
+$count = Sections::count_for_anchor(NULL, TRUE);
 
 // a meta link to our blogging interface
 $context['page_header'] .= "\n".'<link rel="EditURI" href="'.$context['url_to_home'].$context['url_to_root'].'services/describe.php" title="RSD" type="application/rsd+xml" />';
@@ -98,14 +94,17 @@ if(is_callable(array('Hooks', 'include_scripts')))
 	$context['text'] .= Hooks::include_scripts('sections/index.php#prefix');
 
 // stop hackers
-if($page > 10) {
+if(($page > 1) && (($page - 1) * $items_per_page > $count)) {
 	Safe::header('Status: 401 Unauthorized', TRUE, 401);
 	Logger::error(i18n::s('You are not allowed to perform this operation.'));
 
 } else {
 
-	// page main content
+	// page main content -- the listing below is extended to sections managed
+	// by this surfer, which Cache::put() does not discriminate on its own
 	$cache_id = 'sections/index.php#text#'.$page;
+	if($signature = Surfer::get_assignment_signature(FALSE))
+		$cache_id .= '#'.$signature;
 	if(!$text = Cache::get($cache_id)) {
 
 		// load the layout to use
@@ -122,7 +121,7 @@ if($page > 10) {
 			$items = Skin::build_list($items, '2-columns');
 
 		// navigation commands for sections, if necessary
-		if($count > 20) {
+		if($count > $items_per_page) {
 
 			$menu = array('_count' => Skin::build_number($count, i18n::s('sections')));
 

--- a/sections/sections.php
+++ b/sections/sections.php
@@ -738,22 +738,19 @@ Class Sections {
 	/**
 	 * count records for some anchor
 	 *
-	 * Only sections matching following criteria are counted:
-	 * - section is visible (active='Y')
-	 * - section is restricted (active='R'), but surfer is a logged user
-	 * - section is hidden (active='N'), but surfer is an associate
+	 * Counted sections are those that Sections::list_for_anchor_by() would
+	 * list for the same anchor, so that a count and the listing it introduces
+	 * cannot disagree. Scope is set by Sections::get_sql_where(), and
+	 * non-activated and expired sections are counted for associates only.
 	 *
-	 * Non-activated and expired sections are counted as well.
+	 * Pass a NULL anchor to count sections of the top level.
 	 *
-	 * @param string the selected anchor (e.g., 'section:12')
+	 * @param string the selected anchor (e.g., 'section:12'), or NULL for the top level
+	 * @param boolean TRUE to count only sections that are part of index maps
 	 * @return int resulting count, or NULL on error
 	 */
-	public static function count_for_anchor($anchor) {
+	public static function count_for_anchor($anchor, $with_index_map=FALSE) {
 		global $context;
-
-		// sanity check
-		if(!$anchor)
-			return NULL;
 
 		// limit the query to one level
 		if($anchor)
@@ -761,27 +758,15 @@ Class Sections {
 		else
 			$where = "(sections.anchor='' OR sections.anchor is NULL)";
 
-		// display active and restricted items
-		$where .= " AND (sections.active='Y'";
+		// limit the scope of the request
+		$where .= " AND ".Sections::get_sql_where();
 
-		// list restricted sections to authenticated surfers
-		if(Surfer::is_logged())
-			$where .= " OR sections.active='R'";
-
-		// list hidden sections to associates, editors and readers
-		if(Surfer::is_empowered('S'))
-			$where .= " OR sections.active='N'";
-
-		// include managed sections
-		if($my_sections = Surfer::assigned_sections()) {
-			$where .= " OR sections.id IN (".join(", ", $my_sections).")";
-			$where .= " OR sections.anchor IN ('section:".join("', 'section:", $my_sections)."')";
-		}
-
-		$where .= ")";
+		// hide sections removed from index maps
+		if($with_index_map)
+			$where .= " AND (sections.index_map = 'Y')";
 
 		// non-associates will have only live sections
-		if($anchor && !Surfer::is_empowered()) {
+		if(!Surfer::is_associate()) {
 			$where .= " AND ((sections.activation_date is NULL)"
 				."	OR (sections.activation_date <= '".$context['now']."'))"
 				." AND ((sections.expiry_date is NULL)"

--- a/shared/surfer.php
+++ b/shared/surfer.php
@@ -64,6 +64,49 @@ Class Surfer {
 	}
 
 	/**
+	 * signature of the private scope of this surfer
+	 *
+	 * Listings are restricted by functions such as Articles::get_sql_where(),
+	 * which extend their scope to items this surfer has been assigned to.
+	 * These items differ from one surfer to the next, while Cache::put() only
+	 * splits its entries per capability, per language and per time offset.
+	 *
+	 * Therefore this signature has to be appended to the cache id of any
+	 * listing that goes through such a filter. Surfers that share the same
+	 * assignments, including all those that have none, do share cached items.
+	 *
+	 * Pass FALSE to skip assigned articles, for listings such as the site map
+	 * that are widened by assigned sections only. This keeps the number of
+	 * cached variants down to the number of distinct section assignments.
+	 *
+	 * @param boolean TRUE to also consider articles assigned to this surfer
+	 * @return string a token, or an empty string for surfers without assignment
+	 */
+	public static function get_assignment_signature($with_articles=TRUE) {
+
+		// anonymous surfers have no assignment
+		if(!Surfer::get_id())
+			return '';
+
+		// the private scope of this surfer -- prefixes keep ids of both tables apart
+		$items = array();
+		foreach(Surfer::assigned_sections() as $id)
+			$items[] = 's'.$id;
+		if($with_articles)
+			foreach(Surfer::assigned_articles() as $id)
+				$items[] = 'a'.$id;
+
+		if(!$items)
+			return '';
+
+		// a stable token for a stable set
+		$items = array_unique($items);
+		sort($items);
+
+		return md5(join(',', $items));
+	}
+
+	/**
 	 * list articles assigned to this surfer
 	 *
 	 * If a member is acting as a managing editor for some articles,


### PR DESCRIPTION
Three defects on sections/index.php, all reproduced on a live install before and after the change.

1. Cached listings were shared between surfers that must not see the same thing. Cache::get() and Cache::put() split their entries per capability, per language and per time offset -- but Sections:: get_sql_where() also widens its scope with Surfer::assigned_sections(), which differs from one member to the next. Every member falls in the same 'M' bucket, so whoever warmed the cache imposed his own site map on all the others for the next twenty minutes.

Measured with two members of the same site, teasers turned off:

  f.M manages       S1, S2, S3
  m.S manages S4, S1, S5

  m.S was served f.M's page: he gained two sections he
  has no right on, and lost the two he actually manages.

Surfer::get_assignment_signature() returns a token for the private scope of a surfer, and is appended to the cache id of listings that go through such a filter. Surfers that share the same assignments -- including all those that have none, which covers anonymous traffic -- still share cached items: on the test install the site map needs three variants for sixteen members, and anonymous surfers keep the very same cache id as before.

articles/index.php has the same defect, since Articles::get_sql_where() extends its scope to assigned sections and articles. Two members were served listings differing by fourteen pages each way. It is fixed the same way, with articles taken into account.

2. Sections::count_for_anchor() returned NULL for the top level, because of a sanity check that rejected an empty anchor -- while the else branch right below it builds the very filter for that level, and could not be reached. sections/index.php:91 is the only caller that counts the top level, so $count was always NULL, 'if($count > 20)' was always false, and the navigation bar was never displayed. A site with more sections than one page could not reach them but by editing the address by hand. The guard has been there since 10.5.27, this is not a regression.

Counted sections were not those that get listed either: no filter on index maps, a different scope on the active field, and date filters applied only when an anchor was provided. The function now shares Sections::get_sql_where() with Sections::list_for_anchor_by(), so a count and the listing it introduces cannot disagree, and it takes the same optional filter on index maps -- FALSE by default, so that management screens keep counting everything.

This does change the numbers displayed next to sections elsewhere in the interface. They now match the listings they introduce: a sub-section badge that read 5 while six sections were listed below now reads 6.

3. Along the way: the page size is 50, but the navigation bar showed up from 20 items and the docblock still described pages of 20. The bar now follows $items_per_page. The 'stop hackers' guard rejected any page beyond the tenth, which capped browsing at 500 sections; it now bounds the requested page against the real count, as categories/index.php already does. And 'if($page < 1)' could not fire after max(1, ...).

The 401 status of that guard would be better as a 403, since no WWW-Authenticate header comes with it. Left alone here, so that both index pages keep saying the same thing; worth fixing in one go.