### PR TITLE
fix: guard against null $item in locations edit/view forms

### DIFF
--- a/locations/edit.php
+++ b/locations/edit.php
@@ -50,7 +50,7 @@ elseif(isset($context['arguments'][0]) && !isset($context['arguments'][1]))
 if($id) $id = strip_tags($id);
 
 // get the item from the database
-$item = Locations::get($id);
+$item = Locations::get($id) ?: array();
 
 // look for the target anchor on item creation
 $target_anchor = NULL;

--- a/locations/view.php
+++ b/locations/view.php
@@ -39,7 +39,7 @@ elseif(isset($context['arguments'][0]))
 $id = strip_tags($id);
 
 // get the item from the database
-$item = Locations::get($id);
+$item = Locations::get($id) ?: array();
 
 // get the related anchor, if any
 $anchor = NULL;


### PR DESCRIPTION
Locations::get() returns NULL when $id is empty (locations.php, "if(!$id)" sanity check). locations/edit.php accepts an anchor-only call with no id (edit.php?anchor=<type>:<id>, used by the native "Add a location" block of the with_locations anchor option), so on location creation $item stays NULL and the form dereferences it without a guard:

  edit.php:228  encode_field($item['geo_place_name'])
  edit.php:295  encode_field($item['geo_position'])
  edit.php:307  encode_field($item['geo_country'])
  edit.php:315  Surfer::get_editor('description', $item['description'])

Under PHP 8.4 each creation emits four "Trying to access array offset on null" warnings into error_log.

locations/view.php:69 has the same defect: it reads $item['geo_place_name'] before the "if(!isset($item['id']))" not-found check on line 73.

Fix both entry points identically with "?: array()". Locations::get() never returns a falsy-but-valid value (either a non-empty SQL row or NULL), so this changes nothing when a valid id is passed; when $item would be NULL the form now renders empty fields, which is the intended creation behaviour.
