### PR TITLE
fix: reject altcha challenge with no payload instead of fatal TypeError

### DIFF
--- a/included/altcha/yaltcha.php
+++ b/included/altcha/yaltcha.php
@@ -114,7 +114,14 @@ Class yaltcha {
         }
         
         $altcha     = new \AltchaOrg\Altcha\Altcha(HMACK);
-        
+
+        // Altcha::verifySolution() is typed array|string, not nullable: a POST
+        // that carries no altcha field (no-JS submission, or a bot posting
+        // straight to the form action) leaves $payload NULL and triggers a fatal
+        // TypeError instead of a plain rejection. Reject such a request quietly.
+        if($payload === NULL)
+            return false;
+
         return $altcha->verifySolution($payload);
     }
     


### PR DESCRIPTION
yaltcha::verify_challenge() reads the altcha field from $_REQUEST and passes it straight to AltchaOrg\Altcha\Altcha::verifySolution(). That vendor method is typed array|string, not nullable. When the field is absent from the POST -- a no-JS submission, or a bot posting directly to the form action without going through the widget -- $payload stays NULL and verifySolution() raises an uncaught TypeError. The visitor (or bot) gets a 500 instead of the form being silently rejected.

Surfer::may_be_a_robot() (shared/surfer.php) is the caller, so any public form guarded by altcha is affected. Seen in production on a "new request" overlay endpoint.

Guard $payload against NULL before the call. A present payload -- valid or invalid -- is unaffected; the library already handles both.