### PR TITLE
fix: guard against missing "featured" category on the front page (PHP…

### DIFF
--- a/index.php
+++ b/index.php
@@ -485,7 +485,7 @@ if(!$text = Cache::get($cache_id)) {
 
 		// the category used to assign featured pages
 		$anchor = Categories::get(i18n::c('featured'));
-		if($anchor['id'] && ($items = Members::list_articles_by_date_for_anchor('category:'.$anchor['id'], 0, ($context['root_featured_count']+1), 'news'))) {
+		if($anchor && $anchor['id'] && ($items = Members::list_articles_by_date_for_anchor('category:'.$anchor['id'], 0, ($context['root_featured_count']+1), 'news'))) {
 
 			// link to the category page from the box title
 			$title = Skin::build_box_title($anchor['title'], Categories::get_permalink($anchor), i18n::s('Featured pages'));


### PR DESCRIPTION
… 8.4)

When the featured-articles box is enabled (root_featured_layout set), index.php resolves the category that tags featured pages:

    $anchor = Categories::get(i18n::c('featured'));
    if($anchor['id'] && ($items = ...

Categories::get() returns NULL when no category has the "featured" nick name, which is the case on any site that never created one. $anchor['id'] is then read on NULL:

    Warning: Trying to access array offset on null in index.php on line 488

The block only runs when the "index.php#extra_news" cache is cold, so the warning shows up intermittently in the logs rather than on every home hit, which makes it puzzling to track down.

Add "$anchor &&" before the dereference. No behaviour change when the category exists.
